### PR TITLE
Factored-out Vec4 Type

### DIFF
--- a/krust-examples/rt1/rt1.cpp
+++ b/krust-examples/rt1/rt1.cpp
@@ -414,22 +414,22 @@ public:
     const float MOVE_SCALE = mMoveScale;
 
     if(mKeyLeft) {
-      kr::store(kr::load(mPushed.ray_origin) + (-kr::load(mPushed.ray_target_right) * MOVE_SCALE) , mPushed.ray_origin);
+      kr::store(kr::loadf3(mPushed.ray_origin) + (-kr::loadf3(mPushed.ray_target_right) * MOVE_SCALE) , mPushed.ray_origin);
     }
     if(mRightKey) {
-      kr::store(kr::load(mPushed.ray_origin) + (kr::load(mPushed.ray_target_right) * MOVE_SCALE) , mPushed.ray_origin);
+      kr::store(kr::loadf3(mPushed.ray_origin) + (kr::loadf3(mPushed.ray_target_right) * MOVE_SCALE) , mPushed.ray_origin);
     }
     if(mKeyFwd) {
-      kr::store(kr::load(mPushed.ray_origin) + kr::cross(kr::load(mPushed.ray_target_up), kr::load(mPushed.ray_target_right)) * MOVE_SCALE, mPushed.ray_origin);
+      kr::store(kr::loadf3(mPushed.ray_origin) + kr::cross(kr::loadf3(mPushed.ray_target_up), kr::loadf3(mPushed.ray_target_right)) * MOVE_SCALE, mPushed.ray_origin);
     }
     if(mKeyBack) {
-      kr::store(kr::load(mPushed.ray_origin) + kr::cross(kr::load(mPushed.ray_target_right), kr::load(mPushed.ray_target_up)) * MOVE_SCALE, mPushed.ray_origin);
+      kr::store(kr::loadf3(mPushed.ray_origin) + kr::cross(kr::loadf3(mPushed.ray_target_right), kr::loadf3(mPushed.ray_target_up)) * MOVE_SCALE, mPushed.ray_origin);
     }
     if(mKeyUp) {
-      kr::store(kr::load(mPushed.ray_origin) + (kr::load(mPushed.ray_target_up) * MOVE_SCALE) , mPushed.ray_origin);
+      kr::store(kr::loadf3(mPushed.ray_origin) + (kr::loadf3(mPushed.ray_target_up) * MOVE_SCALE) , mPushed.ray_origin);
     }
     if(mKeyDown) {
-      kr::store(kr::load(mPushed.ray_origin) + (kr::load(mPushed.ray_target_up) * -MOVE_SCALE) , mPushed.ray_origin);
+      kr::store(kr::loadf3(mPushed.ray_origin) + (kr::loadf3(mPushed.ray_target_up) * -MOVE_SCALE) , mPushed.ray_origin);
     }
     mPushed.ray_origin[1] = kr::clamp(mPushed.ray_origin[1], -30.0f, 1500.0f);
 

--- a/krust-gm/public-api/vec4.h
+++ b/krust-gm/public-api/vec4.h
@@ -1,0 +1,53 @@
+#ifndef KRUST_GM_PUBLIC_API_VEC4_H_
+#define KRUST_GM_PUBLIC_API_VEC4_H_
+
+// Copyright (c) 2021,2024 Andrew Helge Cox
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+/**
+ * @file 3-component vector type, using experimental standard SIMD types when
+ * available and a scalar fallback otherwise.
+ * @note Scalar fallback will be allowed to languish until it is needed.
+ */
+#include "vec4_scalar.h"
+#include "vec4_fwd.h"
+
+// =============================================================================
+// SIMD version
+#if defined(KRUST_GM_BUILD_CONFIG_ENABLE_SIMD)
+
+#include <experimental/simd>
+
+namespace Krust
+{
+    using Vec4 = std::experimental::simd<float, std::experimental::simd_abi::fixed_size<4>>;
+}
+
+// =============================================================================
+// Scalar fall-back
+
+#else // defined(KRUST_GM_BUILD_CONFIG_ENABLE_SIMD)
+namespace Krust
+{
+    #error The scalar fallback for vector types is unfinished. If you have gcc, enable the cached variable KRUST_GM_BUILD_CONFIG_ENABLE_SIMD in cmake config step. Otherwise, ask and I will try to finish it.
+    using Vec4 = Vec4Scalar;
+}
+#endif // defined(KRUST_GM_BUILD_CONFIG_ENABLE_SIMD)
+
+#endif // KRUST_GM_PUBLIC_API_VEC4_H_

--- a/krust-gm/public-api/vec4_fwd.h
+++ b/krust-gm/public-api/vec4_fwd.h
@@ -1,0 +1,56 @@
+#ifndef KRUST_GM_PUBLIC_API_VEC4_FWD_H_
+#define KRUST_GM_PUBLIC_API_VEC4_FWD_H_
+
+// Copyright (c) 2021,2024 Andrew Helge Cox
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+/**
+ * @file Forward declarations for short vector types so code that doesn't want
+ * to pull in all that template malarkey from the standard SIMD types can still
+ * work with them.
+ * @note Forward declaring the template clases failed in August 2021 on gcc due
+ * to some macro magic that is used to open the namespaces in the std headers
+ * being incompatible with just writing them out here in plain text.
+ * @note It is worth having a type for the in-memory representation of vec4s
+ * so that buffers of them can be allocated and member variables declared without
+ * pulling in the full SIMD templates everywhere.
+ */
+
+
+namespace Krust
+{
+class Vec4Scalar;
+
+#if defined(KRUST_GM_BUILD_CONFIG_ENABLE_SIMD)
+    /**
+     * vec4_inl.h has helper funcs:
+     * Vec4 load(&Vec4InMemory vec);
+     * void store(Vec4, &Vec4InMemory vec);
+     */
+    struct alignas(16) Vec4InMemory {
+        float v[4];
+    };
+#else
+    struct Vec4InMemory {
+        float v[4];
+    };
+#endif
+
+}
+#endif // KRUST_GM_PUBLIC_API_VEC4_FWD_H_

--- a/krust-gm/public-api/vec4_inl.h
+++ b/krust-gm/public-api/vec4_inl.h
@@ -1,7 +1,7 @@
-#ifndef KRUST_GM_PUBLIC_API_VEC3_INL_H_
-#define KRUST_GM_PUBLIC_API_VEC3_INL_H_
+#ifndef KRUST_GM_PUBLIC_API_VEC4_INL_H_
+#define KRUST_GM_PUBLIC_API_VEC4_INL_H_
 
-// Copyright (c) 2021 Andrew Helge Cox
+// Copyright (c) 2021,2024 Andrew Helge Cox
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,96 +21,86 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 /**
- * @file Inline functions related to the Vec3 type.
+ * @file Inline functions related to the Vec4 type.
  */
-#include "vec3_fwd.h"
-#include "vec3.h"
+#include "vec4_fwd.h"
+#include "vec4.h"
 
 namespace Krust
 {
 
-    inline Vec3 cross(const Vec3 v, const Vec3 w)
-    {
-        Vec3 result;
-        result[0] = v[1] * w[2] - v[2] * w[1];
-        result[1] = v[2] * w[0] - v[0] * w[2];
-        result[2] = v[0] * w[1] - v[1] * w[0];
-        return result;
-    }
-
 #if defined(KRUST_GM_BUILD_CONFIG_ENABLE_SIMD)
-    inline Vec3 load(const Vec3InMemory& vmem)
+    inline Vec4 load(const Vec4InMemory& vmem)
     {
-        Vec3 vec;
-        //vec.copy_from(&vmem.v[0], std::experimental::vector_aligned); // compiles
-        //vec.copy_from(&vmem.v[0], std::experimental::overaligned<16>); // compiles
-        vec.copy_from(&vmem.v[0], std::experimental::overaligned<alignof(Vec3InMemory)>); // compiles. Hope it is same as vector_aligned when we align the in-memory type to 16.
+        Vec4 vec;
+        vec.copy_from(&vmem.v[0], std::experimental::overaligned<alignof(Vec4InMemory)>); // compiles. Hope it is same as vector_aligned when we align the in-memory type to 16.
         return vec;
     }
 
-    inline Vec3 loadf3(const float vmem[3])
+    inline Vec4 loadf4(const float vmem[4])
     {
-        Vec3 vec;
+        Vec4 vec;
         vec.copy_from(vmem, std::experimental::element_aligned);
         return vec;
     }
 
-    inline void store(const Vec3 vec, Vec3InMemory& vmem)
+    inline void store(const Vec4 vec, Vec4InMemory& vmem)
     {
-        vec.copy_to(&vmem.v[0], std::experimental::overaligned<alignof(Vec3InMemory)>);
+        vec.copy_to(&vmem.v[0], std::experimental::overaligned<alignof(Vec4InMemory)>);
     }
 
-    inline void store(const Vec3 vec, float vmem[3])
+    inline void store(const Vec4 vec, float vmem[4])
     {
         vec.copy_to(vmem, std::experimental::element_aligned);
     }
 
     /// Horizontal add components in vector.
-    inline float hadd(const Vec3 vec)
+    inline float hadd(const Vec4 vec)
     {
         return reduce(vec);
     }
 
-    inline float dot(const Vec3 v1, const Vec3 v2)
+    inline float dot(const Vec4 v1, const Vec4 v2)
     {
         return reduce(v1 * v2);
     }
 
-    inline Vec3 make_vec3(const float v[3])
+    inline Vec4 make_vec4(const float v[4])
     {
-        Vec3 vec(v, std::experimental::element_aligned);
+        Vec4 vec(v, std::experimental::element_aligned);
         return vec;
     }
 
-    inline Vec3 make_vec3(const float x, const float y, const float z)
+    inline Vec4 make_vec4(const float x, const float y, const float z, const float w)
     {
-        Vec3 vec;
+        Vec4 vec;
         vec[0] = x;
         vec[1] = y;
         vec[2] = z;
+        vec[3] = w;
         return vec;
     }
 
-    inline Vec3 make_vec3(const Vec3 vec)
+    inline Vec4 make_vec4(const Vec4 vec)
     {
         return vec;
     }
 
 #else // defined(KRUST_GM_BUILD_CONFIG_ENABLE_SIMD)
-inline Vec3 load(Vec3InMemory& vmem)
+inline Vec4 load(Vec4InMemory& vmem)
     {
-        Vec3 vec {vmem.v[0], vmem.v[1], vmem.v[2]};
+        Vec4 vec {vmem.v[0], vmem.v[1], vmem.v[2]};
         return vec;
     }
 
-    inline void store(const Vec3 vec, Vec3InMemory& vmem)
+    inline void store(const Vec4 vec, Vec4InMemory& vmem)
     {
         vmem.v[0] = vec[0];
         vmem.v[1] = vec[1];
         vmem.v[2] = vec[2];
     }
 
-    inline float dot(const Vec3 v1, const Vec3 v2)
+    inline float dot(const Vec4 v1, const Vec4 v2)
     {
         return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
     }
@@ -119,4 +109,4 @@ inline Vec3 load(Vec3InMemory& vmem)
 
 }
 
-#endif // KRUST_GM_PUBLIC_API_VEC3_INL_H_
+#endif // KRUST_GM_PUBLIC_API_VEC4_INL_H_

--- a/krust-gm/public-api/vec4_scalar.h
+++ b/krust-gm/public-api/vec4_scalar.h
@@ -1,0 +1,51 @@
+#ifndef KRUST_GM_PUBLIC_API_VEC4_SCALAR_H_
+#define KRUST_GM_PUBLIC_API_VEC4_SCALAR_H_
+
+// Copyright (c) 2021,2024 Andrew Helge Cox
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+/**
+ * @file A version of the Vec4 type that uses straightforward scalar floating
+ * point as a fallback for when SIMD is not available or not performant,
+ * and potentially when SIMD units are utilised by scheduling separate scalar
+ * instances to each lane (GPU or ISPC-style).
+ */
+#include <cstddef>
+
+namespace Krust
+{
+
+class Vec4Scalar {
+    float v[4];
+public:
+    float operator [] (const size_t i) const {
+        return v[i];
+    }
+
+    operator float* () {
+        return v;
+    }
+
+    operator const float* () const {
+        return v;
+    }
+};
+
+}
+#endif // KRUST_GM_PUBLIC_API_VEC4_SCALAR_H_

--- a/krust-tests/CMakeLists.txt
+++ b/krust-tests/CMakeLists.txt
@@ -21,9 +21,13 @@ target_link_libraries(krust-test-simple krust-io krust krust-kernel pthread)
 # ToDo: move this test to the krust-gm directory.
 
 add_executable (krust-test-gm
+  krust-test-gm-main.cpp
   krust-test-vec3.cpp
+  krust-test-vec4.cpp
   ${KRUST_PUBLIC_API_HEADER_FILES}
   ${KRUST_GM_PUBLIC_API_HEADER_FILES}
 )
-target_include_directories(krust-test-simple SYSTEM PRIVATE ${VULKAN_INCLUDE_DIRECTORY})
-target_link_libraries(krust-test-simple krust-kernel krust krust-io pthread)
+target_include_directories(krust-test-gm SYSTEM PRIVATE ${VULKAN_INCLUDE_DIRECTORY})
+target_link_libraries(krust-test-gm krust-gm krust-kernel krust krust-io pthread)
+
+include(CTest) # ToDo discover the catch tests automatically and populate vscode test gui (requires catch 2 v3 upgrade?).

--- a/krust-tests/krust-test-gm-main.cpp
+++ b/krust-tests/krust-test-gm-main.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Andrew Helge Cox
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"

--- a/krust-tests/krust-test-vec3.cpp
+++ b/krust-tests/krust-test-vec3.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Andrew Helge Cox
+// Copyright (c) 2021,2024 Andrew Helge Cox
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-#define CATCH_CONFIG_MAIN
+
 #include "catch.hpp"
 
 /* ----------------------------------------------------------------------- *//**

--- a/krust-tests/krust-test-vec4.cpp
+++ b/krust-tests/krust-test-vec4.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2021,2024 Andrew Helge Cox
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "catch.hpp"
+
+/* ----------------------------------------------------------------------- *//**
+ * @file Test of the Vec4 class.
+ */
+#include "krust-gm/public-api/vec4.h"
+#include "krust-gm/public-api/vec4_inl.h"
+namespace {
+namespace kr = Krust;
+
+TEST_CASE("Vec4 Template", "[gm]")
+{
+  bool destroyed = false;
+  REQUIRE(destroyed == false);
+}
+
+TEST_CASE("Vec4 dot", "[gm]")
+{
+    auto v1 = kr::make_vec4(1, 1, 1, 1);
+    auto v2 = kr::make_vec4(2, 2, 2, 2);
+    REQUIRE(kr::dot(v1, v1) == 4.0f);
+    REQUIRE(kr::dot(v1, v2) == 8.0f);
+    REQUIRE(kr::dot(v2, v2) == 16.0f);
+    auto v3 = kr::make_vec4(2.28383383f, 19.2282f, 0.8292746462f, 0.18388383f);
+    REQUIRE(kr::dot(v1, v3) == 2.28383383f + 19.2282f + 0.8292746462f + 0.18388383f);
+    REQUIRE(kr::dot(v1, v3) == kr::hadd(v3));
+}
+
+TEST_CASE("Vec4 load", "[gm]")
+{
+    float vmem[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    kr::Vec4 v1 = kr::loadf4(vmem);
+    REQUIRE(v1[0] == 1.0f);
+    REQUIRE(v1[1] == 2.0f);
+    REQUIRE(v1[2] == 3.0f);
+    REQUIRE(v1[3] == 4.0f);
+}
+
+TEST_CASE("Vec4 store", "[gm]")
+{
+    float vmem[4] = {-1.0f, -2.0f, -3.0f, -4.0f};
+    kr::Vec4 v1 = kr::make_vec4(1, 2, 3, 4);
+    kr::store(v1, vmem);
+    REQUIRE(vmem[0] == 1.0f);
+    REQUIRE(vmem[1] == 2.0f);
+    REQUIRE(vmem[2] == 3.0f);
+    REQUIRE(vmem[3] == 4.0f);
+}
+
+TEST_CASE("Vec4 load struct", "[gm]")
+{
+    const kr::Vec4InMemory vmem = {1.0f, 2.0f, 3.0f, 4.0f};
+    kr::Vec4 v1 = kr::load(vmem);
+    REQUIRE(v1[0] == 1.0f);
+    REQUIRE(v1[1] == 2.0f);
+    REQUIRE(v1[2] == 3.0f);
+    REQUIRE(v1[3] == 4.0f);
+}
+
+TEST_CASE("Vec4 store struct", "[gm]")
+{
+    kr::Vec4InMemory vmem = {-1.0f, -2.0f, -3.0f, -4.0f};
+    kr::Vec4 v1 = kr::make_vec4(1, 2, 3, 4);
+    kr::store(v1, vmem);
+    REQUIRE(vmem.v[0] == 1.0f);
+    REQUIRE(vmem.v[1] == 2.0f);
+    REQUIRE(vmem.v[2] == 3.0f);
+    REQUIRE(vmem.v[3] == 4.0f);
+}
+
+TEST_CASE("Vec4 compound", "[gm]")
+{
+    kr::Vec4InMemory vmem1 = { 1.0f,  2.0f,  3.0f,  4.0f};
+    kr::Vec4InMemory vmem2 = {-1.0f, -2.0f, -3.0f, -4.0f};
+    float vmem3[4]         = { 10.0f,  20.0f,  30.0f,  40.0f};
+    float vmem4[4]         = {-10.0f, -20.0f, -30.0f, -40.0f};
+    kr::Vec4 v1 = kr::make_vec4(
+        kr::dot(kr::load(vmem1), kr::load(vmem2)),
+        kr::dot(kr::loadf4(vmem3), kr::loadf4(vmem4)),
+        kr::dot(kr::load(vmem1), kr::loadf4(vmem3)),
+        kr::dot(kr::load(vmem2), kr::loadf4(vmem4))
+    );
+    REQUIRE(v1[0] == -1 + -2*2 + -3*3 + -4*4);
+    REQUIRE(v1[1] == -10*10 + -20*20 + -30*30 + -40*40);
+    REQUIRE(v1[2] == 1 * 10 + 2*20 + 3*30 + 4*40);
+    REQUIRE(v1[3] == -1 * -10 + -2*-20 + -3*-30 + -4*-40);
+}
+
+}


### PR DESCRIPTION
Vec4 is a wrapper around the experimental SIMD support in gcc that might go into the C++ standard, instantiated for 4 floats and with some policy applied and strategies for keeping template code out of headers where possible.