### PR TITLE
Use Opaque and Triangle Skipping Ray Flags

### DIFF
--- a/krust-examples/ray_queries1/ray_queries1.cpp
+++ b/krust-examples/ray_queries1/ray_queries1.cpp
@@ -1206,7 +1206,7 @@ public:
       0,
       0xff, // "an 8-bit visibility mask for the geometry. The instance may only be hit if rayMask & instance.mask != 0"
       0, // instanceShaderBindingTableRecordOffset (not important for us)
-      0, // flags (e.g. make the instance opaque)
+      VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR, // flags (e.g. make the instance opaque)
       vkGetAccelerationStructureDeviceAddressKHR(*mGpuInterface, &blasAddressInfo)
     );
     KRUST_ASSERT1(instance.accelerationStructureReference != 0, "Failed to get the address of the BLAS.");


### PR DESCRIPTION
Also VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR on TLAS.

Made zero difference to Nvidia drivers on RTX3060M under Ubuntu.